### PR TITLE
Factored environment configurations out from the workflow files

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,0 +1,2 @@
+ONTOLOGY_NAME=microscopy
+ONTOLOGY_IRI=https://w3id.org/emmo/domain/microscopy

--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -3,10 +3,6 @@ on:
   push:
     branches: [master]
 
-env:
-  ONTOLOGY_NAME: microscopy
-  ONTOLOGY_IRI: https://w3id.org/emmo/domain/microscopy
-
 permissions:
   contents: write
 
@@ -17,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Set environment
+      run: cat .github/env >> $GITHUB_ENV
+
     - name: Checkout
       uses: actions/checkout@v4
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -1,15 +1,15 @@
 name: CI tests
 on: [push]
 
-env:
-  ONTOLOGY_NAME: microscopy
-
 jobs:
   ci_testing:
     concurrency: ci-${{ github.ref }}  # Recommended if you intend to make multiple deployments in quick succession.
     runs-on: ubuntu-latest
 
     steps:
+    - name: Set environment
+      run: cat .github/env >> $GITHUB_ENV
+
     - name: Checkout
       uses: actions/checkout@v4
 


### PR DESCRIPTION
If this works, the domain ontology developers can simply copy ci/cd files under `.github/workflows/` without having to make any changes. 

The only file that needs to be adapted is `.github/env`. 

**TODO**: the ontology kit should add functionality to create (and potentially update) these files.

If we don't get this to work, the ontology kit could still generate the original version of the workflow files with the correct values of the environment variables inserted.